### PR TITLE
Update worker_init_fn

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -76,7 +76,7 @@ def seed_everything(seed=11):
 #   设置Dataloader的种子
 #---------------------------------------------------#
 def worker_init_fn(worker_id, rank, seed):
-    worker_seed = rank + seed
+    worker_seed = rank + seed + worker_id
     random.seed(worker_seed)
     np.random.seed(worker_seed)
     torch.manual_seed(worker_seed)


### PR DESCRIPTION
如果初始化的时候不添加工作号，会导致在 Linux 上训练时，每个批次取出的数据都是相同的。每批的误差计算都是相等重复的。